### PR TITLE
Change to SearchResults method and add new ViewModel

### DIFF
--- a/gybitg/Controllers/SearchController.cs
+++ b/gybitg/Controllers/SearchController.cs
@@ -70,6 +70,7 @@ namespace gybitg.Controllers
                       || _statsRepository.FTMG.Where(ap => ap.UserId == a.Id) == SearchFTMG)
                     {
                         SearchResultsViewModel srA = new SearchResultsViewModel();
+                        srA.UserId = a.Id;
                         srA.FullName = a.FullName;
                         srA.Position = a.Position;
                         srA.HSGraduationDate = _athleteRepository.HSGraduationDate.Where(ap => ap.UserId == a.Id);

--- a/gybitg/Controllers/SearchController.cs
+++ b/gybitg/Controllers/SearchController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿/*File created by Daniel Watkins*/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,8 +12,6 @@ using Microsoft.Extensions.Logging;
 using gybitg.Services;
 using gybitg.Data;
 using Microsoft.AspNetCore.Mvc.Rendering;
-
-// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
 namespace gybitg.Controllers
 {
@@ -36,7 +35,7 @@ namespace gybitg.Controllers
             _athleteRepository = athleteRepository;
         }
 
-        //Parameters should be passed from the AdvancedSearch post method and the BasicSearch post method
+        //IMPORTANT: Parameters should be passed from the AdvancedSearch post method and the BasicSearch post method
         [HttpGet]
         public async Task<IActionResult> SearchResults(string SearchName, string SearchPosition, DateTime SearchGraduation, decimal SearchPPG, decimal SearchMPG, decimal SearchTPMG, decimal SearchFTMG)
         {
@@ -46,7 +45,7 @@ namespace gybitg.Controllers
 
             List<SearchResultsViewModel> athletes = new List<SearchResultsViewModel>();
 
-            /*This if statement checks to see that at least some search parameters are not default*/
+            /*This if statement checks to see that at least one search parameters is not default*/
             if (!string.IsNullOrEmpty(SearchName) || !string.IsNullOrEmpty(SearchPosition) || SearchGraduation != DateTime.MinValue 
                 || SearchPPG != 0M || SearchMPG != 0M || SearchTPMG != 0M || SearchFTMG != 0M)
             {
@@ -72,10 +71,10 @@ namespace gybitg.Controllers
                     }
                 }
             }
-            /*default search returns all athletes*/
+            /*default search returns all athletes - only happens when all search fields are left blank*/
             else
             {
-                //runs through all athlete users
+                //runs through all athlete users and adds them to the list of athletes to return
                 foreach (var a in usersOfRole)
                 {
                     SearchResultsViewModel srA = new SearchResultsViewModel();

--- a/gybitg/Controllers/SearchController.cs
+++ b/gybitg/Controllers/SearchController.cs
@@ -18,17 +18,7 @@ namespace gybitg.Controllers
 {
     public class SearchController : Controller
     {
-        //Start of old Idea
-        //private IAthleteProfileRepository athleteRepository;
-        //private IApplicationUserRepository userRepository;
-        //private IAthleteStatsRepository statsRepository;
 
-        //public ViewResult SearchResults(string SearchName, string SearchPosition, DateTime SearchGraduation, decimal SearchPPG, decimal SearchMPG, decimal SearchTPMG, decimal SearchFTMG)         
-        //    => View(new SearchResultsViewModel
-        //    {
-
-        //    });
-        //Start of new Idea
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly ApplicationDbContext _context;
         private readonly IAthleteStatsRepository _statsRepository;

--- a/gybitg/Controllers/SearchController.cs
+++ b/gybitg/Controllers/SearchController.cs
@@ -35,13 +35,36 @@ namespace gybitg.Controllers
             _athleteRepository = athleteRepository;
         }
 
+        [HttpPost]
+        public IActionResult AdvancedSearch(SearchViewModel athleteSearched)
+        {
+            if (ModelState.IsValid)
+            {
+                return RedirectToAction("SearchResults", athleteSearched);
+            }
+            else
+            {
+                //there is something wrong with the data values
+                return View(athleteSearched);
+            }
+        }
+
         //IMPORTANT: Parameters should be passed from the AdvancedSearch post method and the BasicSearch post method
         [HttpGet]
-        public async Task<IActionResult> SearchResults(string SearchName, string SearchPosition, DateTime SearchGraduation, decimal SearchPPG, decimal SearchMPG, decimal SearchTPMG, decimal SearchFTMG)
+        public async Task<IActionResult> SearchResults(SearchViewModel SearchParam)
         {
             //Next two lines splits the athlete users from the coach users 
             string roleName = "Athlete";
             var usersOfRole = await _userManager.GetUsersInRoleAsync(roleName);
+
+            //Splits up SearchViewModel SearchParam in to components to save typing later
+            string SearchName = SearchParam.Name;
+            string SearchPosition = SearchParam.Position.ToString();
+            DateTime SearchGraduation = SearchParam.HSGraduationDate;
+            decimal SearchPPG = SearchParam.PPG;
+            decimal SearchMPG = SearchParam.MPG;
+            decimal SearchTPMG = SearchParam.TPMG;
+            decimal SearchFTMG = SearchParam.FTMG;
 
             List<SearchResultsViewModel> athletes = new List<SearchResultsViewModel>();
 
@@ -53,7 +76,7 @@ namespace gybitg.Controllers
                 foreach(var a in usersOfRole)
                 {
                     //Checks to see if any part of the athlete matches the search parameters and if any part does add them to the list of athletes to return
-                    if(/*a.FirstName.Contains(SearchName) || a.LastName.Contains(SearchName) ||*/ a.FullName.Contains(SearchName) || a.Position.Contains(SearchPosition) 
+                    if(a.FullName.Contains(SearchName) || a.Position.Contains(SearchPosition) 
                       || _athleteRepository.HSGraduationDate.Where(ap => ap.UserId == a.Id) == SearchGraduation || _statsRepository.PPG.Where(ap => ap.UserId == a.Id) == SearchPPG 
                       || _statsRepository.MPG.Where(ap => ap.UserId == a.Id) == SearchMPG || _statsRepository.TPMG.Where(ap => ap.UserId == a.Id) == SearchTPMG 
                       || _statsRepository.FTMG.Where(ap => ap.UserId == a.Id) == SearchFTMG)

--- a/gybitg/Models/SearchViewModels/SearchResultsViewModel.cs
+++ b/gybitg/Models/SearchViewModels/SearchResultsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿/*File Created by Daniel Watkins 4/13/2019*/
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/gybitg/Models/SearchViewModels/SearchViewModel.cs
+++ b/gybitg/Models/SearchViewModels/SearchViewModel.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace gybitg.Models.SearchViewModels
+{
+    public class SearchViewModel
+    {
+        [Display(Name = "Name")]
+        public virtual string Name { get; set; }
+
+        [Display(Name = "Position")]
+        public PositionType Position { get; set; }
+
+        [DisplayFormat(DataFormatString = "{0:yyyy-MM}", ApplyFormatInEditMode = true)]
+        [Display(Name = "HS Graduation Date"), DataType(DataType.Date)]
+        public DateTime HSGraduationDate { get; set; }
+
+        [Display(Name = "Points per Game")]
+        public decimal PPG { get; set; }
+
+        [Display(Name = "Average Minutes per Game")]
+        public decimal MPG { get; set; }
+
+        [Display(Name = "Three Pointers Made per Game")]
+        public decimal TPMG { get; set; }
+
+        [Display(Name = "Free Throws Made per Game")]
+        public decimal FTMG { get; set; }
+
+        //Designate only specific types of Positions
+        public enum PositionType
+        {
+            PointGuard,
+            ShootingGuard,
+            SmallForward,
+            PowerForward,
+            Center
+        }
+    }
+}

--- a/gybitg/Views/Search/SearchResults.cshtml
+++ b/gybitg/Views/Search/SearchResults.cshtml
@@ -1,4 +1,6 @@
-﻿@using Microsoft.AspNetCore.Identity
+﻿@*File created by Daniel Watkins 4/10/2019*@
+
+@using Microsoft.AspNetCore.Identity
 @using gybitg.Models
 @using Microsoft.AspNetCore.Mvc
 @using gybitg.Views.Manage


### PR DESCRIPTION
Added a post method for advanced search that takes a new Model called SearchViewModel and passes it to SearchResults. This meant I had to change SearchResults to both take a SearchViewModel as a parameter and search through that model's parts. This means both basic and advanced search need to pass the same model to SearchResults. The new model I made should be fine for both basic and advanced search views.