### PR TITLE
Position SelectList - Close #86 and #95

### DIFF
--- a/gybitg/Controllers/ManageController.cs
+++ b/gybitg/Controllers/ManageController.cs
@@ -87,8 +87,6 @@ namespace gybitg.Controllers
                     PhoneNumber = user.PhoneNumber,
                     FirstName = user.FirstName,
                     LastName = user.LastName,
-                    //Position = (IndexViewModel.PositionType)Enum.Parse(typeof(IndexViewModel.PositionType), user.Position),
-                    //Position = user.Position,
                     City = user.City,
                     State = user.State,
                     Zip = user.Zip,
@@ -112,27 +110,6 @@ namespace gybitg.Controllers
                 IsEmailConfirmed = user.EmailConfirmed,
                 StatusMessage = StatusMessage
             };
-            return View(model);
-
-
-
-
-            /*var model = new IndexViewModel
-            {
-                Username = user.Email,
-                Email = user.Email,
-                PhoneNumber = user.PhoneNumber,
-                FirstName = user.FirstName,
-                LastName = user.LastName,
-                Position = (IndexViewModel.PositionType)Enum.Parse(typeof(IndexViewModel.PositionType), user.Position),
-                //Position = user.Position,
-                City = user.City,
-                State = user.State,
-                Zip = user.Zip,
-                IsEmailConfirmed = user.EmailConfirmed,
-                StatusMessage = StatusMessage
-            };*/
-
             return View(model);
         }
 

--- a/gybitg/Models/ManageViewModels/IndexViewModel.cs
+++ b/gybitg/Models/ManageViewModels/IndexViewModel.cs
@@ -42,16 +42,14 @@ namespace gybitg.Models.ManageViewModels
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 
-        [Display(Name = "Position")]
-        public PositionType Position { get; set; }   //PositionType
         //We were wanting to have the above Position be of type PositionType
         //Creates issues with the rest of the code however in ManageController line 88 comparing Position to user.Position
         //Also breaks program at Index.cshtml at the coach position check line 42
+        [Display(Name = "Position")]
+        public PositionType Position { get; set; }
 
-        //Designate only specific types of Positions
         public enum PositionType
         {
-            Default,
             [Display(Name = "Point Guard")]
             PointGuard,
             [Display(Name = "Shooting Guard")]
@@ -60,6 +58,7 @@ namespace gybitg.Models.ManageViewModels
             SmallForward,
             [Display(Name = "Power Forward")]
             PowerForward,
+            [Display(Name = "Center")]
             Center
         }
 

--- a/gybitg/Models/SearchViewModels/SearchViewModel.cs
+++ b/gybitg/Models/SearchViewModels/SearchViewModel.cs
@@ -15,6 +15,20 @@ namespace gybitg.Models.SearchViewModels
         [Display(Name = "Position")]
         public PositionType Position { get; set; }
 
+        public enum PositionType
+        {
+            [Display(Name = "Point Guard")]
+            PointGuard,
+            [Display(Name = "Shooting Guard")]
+            ShootingGuard,
+            [Display(Name = "Small Forward")]
+            SmallForward,
+            [Display(Name = "Power Forward")]
+            PowerForward,
+            [Display(Name = "Center")]
+            Center
+        }
+
         [RegularExpression("^[0-9/]{7}$", ErrorMessage = "Only this format allowed: mm/yyyy")]
         [Display(Name = "HS Graduation Date")]
         public string HSGraduationDate { get; set; }
@@ -34,20 +48,5 @@ namespace gybitg.Models.SearchViewModels
         [RegularExpression("^[a-zA-Z .&'-]*$", ErrorMessage = "Only Alphabetical characters allowed.")]
         [Display(Name = "High School Coach")]
         public string HighScoolCoach { get; set; }
-
-        //Designate only specific types of Positions
-        public enum PositionType
-        {
-            Default,
-            [Display(Name = "Point Guard")]
-            PointGuard,
-            [Display(Name = "Shooting Guard")]
-            ShootingGuard,
-            [Display(Name = "Small Guard")]
-            SmallForward,
-            [Display(Name = "Power Guard")]
-            PowerForward,
-            Center
-        }
     }
 }

--- a/gybitg/Program.cs
+++ b/gybitg/Program.cs
@@ -84,7 +84,7 @@ namespace gybitg
                 var services = scope.ServiceProvider;
                 try
                 {
-                    SeedData.InitializeAsync(services).Wait();
+                    SeedData.Initialize(services);
                 }
                 catch (Exception ex)
                 {

--- a/gybitg/SeedData.cs
+++ b/gybitg/SeedData.cs
@@ -13,12 +13,12 @@ namespace gybitg
 {
     public class SeedData
     {
-        public static async Task InitializeAsync(IServiceProvider services)
+        public static void Initialize(IServiceProvider services)
         {
-            await Seed(services.GetRequiredService<ApplicationDbContext>());
+            Seed(services.GetRequiredService<ApplicationDbContext>());
         }
 
-        public static async Task Seed(ApplicationDbContext context)
+        public static void Seed(ApplicationDbContext context)
         {
             if (context.AthleteUserViewModel.Any())
             {
@@ -186,7 +186,7 @@ namespace gybitg
             */
 
             //context.SaveChanges();
-            
+
         }
     }
 }

--- a/gybitg/Views/Manage/Index.cshtml
+++ b/gybitg/Views/Manage/Index.cshtml
@@ -47,7 +47,7 @@
 			{
 			<div class="form-group">
 				<label asp-for="Position"></label>
-				<select asp-for="Position" class="form-control" asp-items="@new SelectList(Enum.GetNames(typeof(SearchViewModel.PositionType)))"></select>
+				<select asp-for="Position" class="form-control" asp-items="Html.GetEnumSelectList<IndexViewModel.PositionType>()"><option value="user.Position" selected>--Select--</option></select>
 				<span asp-validation-for="Position" class="text-danger"></span>
 			</div>
 			}

--- a/gybitg/Views/Search/AdvancedSearch.cshtml
+++ b/gybitg/Views/Search/AdvancedSearch.cshtml
@@ -24,8 +24,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Position"></label>
-                <select asp-for="Position" class="form-control" asp-items="@new SelectList(Enum.GetNames(typeof(SearchViewModel.PositionType)))"></select>
-                <span asp-validation-for="Position" class="text-danger"></span>
+                <select asp-for="Position" class="form-control" asp-items="Html.GetEnumSelectList<SearchViewModel.PositionType>()"><option value="" selected>--Select--</option></select>
             </div>
             <div class="form-group">
                 <label asp-for="HSGraduationDate"></label>


### PR DESCRIPTION
Finished changes to add 'space' support within Position drop down lists while retaining the enum type; so PointGuard shows to users as 'Point Guard' instead. Also restructured the default selection for the SelectList. It will now show the current user.Position if it exists within manage, or --Select-- as default otherwise. These changes are for the Manage Account pages and the Advanced Search pages.