### PR TITLE
New account reroute from login, to manage index - Close #101

### DIFF
--- a/gybitg/Controllers/AccountController.cs
+++ b/gybitg/Controllers/AccountController.cs
@@ -112,8 +112,7 @@ namespace gybitg.Controllers
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User logged in.");
-                    //return RedirectToLocal(returnUrl);
-                    return RedirectToAction("Index", "Manage");
+                    return RedirectToLocal(returnUrl);
                 }
                 
                 if (result.RequiresTwoFactor)

--- a/gybitg/Controllers/AccountController.cs
+++ b/gybitg/Controllers/AccountController.cs
@@ -93,7 +93,7 @@ namespace gybitg.Controllers
         {
             // Clear the existing external cookie to ensure a clean login process
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
-
+            
             ViewData["ReturnUrl"] = returnUrl;
             return View();
         }
@@ -112,7 +112,8 @@ namespace gybitg.Controllers
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User logged in.");
-                    return RedirectToLocal(returnUrl);
+                    //return RedirectToLocal(returnUrl);
+                    return RedirectToAction("Index", "Manage");
                 }
                 
                 if (result.RequiresTwoFactor)
@@ -325,9 +326,12 @@ namespace gybitg.Controllers
 
                         await _emailSender.SendEmailConfirmationAsync(model.Email, callbackUrl);
 
+                        // To create account and return (still logged out) to the login page: comment out just SignInManager and RedirectToAction below
+                        // To create account and be sent (logged in automatically) to manage page: comment out only RedirectToLocal below instead
                         await _signInManager.SignInAsync(user, isPersistent: false);
                         _logger.LogInformation("User created a new account with password.");
-                        return RedirectToLocal(returnUrl);
+                        //return RedirectToLocal(returnUrl);
+                        return RedirectToAction("Index", "Manage");
                     }
 
                     AddErrors(result);


### PR DESCRIPTION
When a new account is created, the user had been routed back to the login page to sign in with the new credentials, however they were already technically logged in, with access to the Manage Account button in the top navigation bar. Now after the account is created, the user is sent to the Manage Account page instead, just like a normal login from a current user would do